### PR TITLE
Newfilter

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,8 +13,16 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+
+type InterestFilter = "All" | typeof INTEREST_LEVELS[number];
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
@@ -30,11 +38,20 @@ function KanbanColumn({
   status,
   prospects,
   isLoading,
+  interestFilter,
+  onFilterChange,
 }: {
   status: string;
   prospects: Prospect[];
   isLoading: boolean;
+  interestFilter: InterestFilter;
+  onFilterChange: (filter: InterestFilter) => void;
 }) {
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -43,13 +60,40 @@ function KanbanColumn({
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
         <h3 className="text-sm font-semibold truncate">{status}</h3>
-        <Badge
-          variant="secondary"
-          className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
-        >
-          {prospects.length}
-        </Badge>
+        <div className="ml-auto flex items-center gap-1.5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className={`h-6 w-6 ${interestFilter !== "All" ? "text-primary" : "text-muted-foreground"}`}
+                aria-label={`Filter ${status} by interest level`}
+                data-testid={`filter-trigger-${status.replace(/\s+/g, "-").toLowerCase()}`}
+              >
+                <Filter className="w-3.5 h-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {(["All", ...INTEREST_LEVELS] as InterestFilter[]).map((level) => (
+                <DropdownMenuItem
+                  key={level}
+                  onSelect={() => onFilterChange(level)}
+                  className={interestFilter === level ? "font-semibold bg-accent" : ""}
+                  data-testid={`filter-option-${level.toLowerCase()}-${status.replace(/\s+/g, "-").toLowerCase()}`}
+                >
+                  {level}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
+            data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            {filteredProspects.length}
+          </Badge>
+        </div>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +102,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {interestFilter !== "All" ? `No ${interestFilter.toLowerCase()} interest prospects` : "No prospects"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}
@@ -75,6 +121,9 @@ function KanbanColumn({
 
 export default function Home() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [columnFilters, setColumnFilters] = useState<Record<string, InterestFilter>>(
+    () => Object.fromEntries(STATUSES.map((s) => [s, "All" as InterestFilter]))
+  );
 
   const { data: prospects, isLoading } = useQuery<Prospect[]>({
     queryKey: ["/api/prospects"],
@@ -134,6 +183,10 @@ export default function Home() {
               status={status}
               prospects={groupedByStatus[status] || []}
               isLoading={isLoading}
+              interestFilter={columnFilters[status] || "All"}
+              onFilterChange={(filter) =>
+                setColumnFilters((prev) => ({ ...prev, [status]: filter }))
+              }
             />
           ))}
         </div>

--- a/replit.md
+++ b/replit.md
@@ -20,7 +20,7 @@ server/
   prospect-helpers.ts         - Pure helper functions (getNextStatus, validateProspect, isTerminalStatus)
 client/src/
   App.tsx                     - Root component, routing, providers
-  pages/home.tsx              - Kanban board with 7 status columns
+  pages/home.tsx              - Kanban board with 7 status columns, per-column interest level filters
   components/
     prospect-card.tsx         - Card component with edit/delete actions
     add-prospect-form.tsx     - Dialog form for creating prospects


### PR DESCRIPTION
Want to filter each column by interest level (Low/Medium/High/All). Each column should have its own independent filter. Filtering should not call the server — just show/hide job cards.

- [x] Issue created in GitHub
- [x] Each status column has its own interest level filter
- [x] Selecting High/Medium/Low shows only matching cards in that column
- [x] Selecting All restores all cards in that column
- [x] Commit pushed and PR merged to main
- [x] Issue closed